### PR TITLE
Compare committed dist with expected

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -39,3 +39,28 @@ jobs:
 
       - name: Format
         run: yarn format
+
+  dist:
+    name: Verify committed dist directory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Calculate hash of committed `dist` directory
+        run: echo "COMMITTED_HASH=${{ hashFiles('./dist/**') }}" >> $GITHUB_ENV
+
+      - run: yarn install
+
+      - name: Calculate expected hash of `dist` directory
+        run: |
+          rm -rf dist && yarn run build
+          echo "EXPECTED_HASH=${{ hashFiles('./dist/**') }}" >> $GITHUB_ENV
+
+      - name: Compare committed and expected hashes
+        run: |
+          echo "COMMITTED_HASH: ${{ env.COMMITTED_HASH }}"
+          echo "EXPECTED_HASH: ${{ env.EXPECTED_HASH }}"
+
+          export RESULT=$(expr "${{ env.COMMITTED_HASH }}" != "${{ env.EXPECTED_HASH }}")
+          echo "RESULT: $RESULT"
+          exit $RESULT


### PR DESCRIPTION
It is expected that `dist` direcotry is commited to the repo. We need to
confirm that the content is really generated for the code.