### PR TITLE
CI job to publish package to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     name: Publish
     needs: build-and-test
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
 
@@ -57,7 +57,7 @@ jobs:
         run: yarn build
 
       - name: Publish pre-release package
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  release:
+    types: [created]
 
 jobs:
   build-and-test:
@@ -32,9 +34,14 @@ jobs:
     name: Publish
     needs: build-and-test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup git credentials
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - uses: actions/setup-node@v2
         with:
@@ -49,7 +56,14 @@ jobs:
       - name: Build
         run: yarn build
 
-      - name: Publish package
-        run: yarn publish --non-interactive --prerelease --preid pre
+      - name: Publish pre-release package
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish release package
+        if: github.event_name == 'release'
+        run: yarn publish --non-interactive --message "Release v%s [skip ci]"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn test
 
       - name: Setup git credentials
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -41,7 +41,7 @@ jobs:
       # On main merge or manual workflow dispatch publish a pre-release package.
       # Automatically bump version based on the current version stored in package.json.
       - name: Publish pre-release package
-        # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -55,5 +55,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push git commit
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: NPM Package Publish
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test
+
+  publish:
+    name: Publish
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish package
+        run: yarn publish --non-interactive --prerelease --preid pre

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@keep-network"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -49,3 +51,5 @@ jobs:
 
       - name: Publish package
         run: yarn publish --non-interactive --prerelease --preid pre
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Publish pre-release package
         # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        # TEST
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,12 +58,12 @@ jobs:
 
       - name: Publish pre-release package
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]"
+        run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish release package
         if: github.event_name == 'release'
-        run: yarn publish --non-interactive --message "Release v%s [skip ci]"
+        run: yarn publish --non-interactive --message "Release v%s [skip ci]" --tag "latest"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-test-publish:
-    name: Build and test
+    name: Build, test and publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,16 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
+      # On main merge or manual workflow dispatch publish a pre-release package.
+      # Automatically bump version based on the current version stored in package.json.
       - name: Publish pre-release package
         # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # On release creation publish a release package with the same version as
+      # the one stored in package.json.
       - name: Publish release package
         if: github.event_name == 'release'
         run: yarn publish --non-interactive --message "Release v%s [skip ci]" --tag "latest"
@@ -51,5 +55,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push git commit
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,38 +10,11 @@ on:
     types: [created]
 
 jobs:
-  build-and-test:
+  build-test-publish:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: Test
-        run: yarn test
-
-  publish:
-    name: Publish
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    # if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup git credentials
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
 
       - uses: actions/setup-node@v2
         with:
@@ -55,6 +28,15 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Test
+        run: yarn test
+
+      - name: Setup git credentials
+        if: github.event_name != 'pull_request'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - name: Publish pre-release package
         # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,14 +33,13 @@ jobs:
         run: yarn test
 
       - name: Setup git credentials
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
       - name: Publish pre-release package
         # if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        # TEST
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,3 +50,7 @@ jobs:
         run: yarn publish --non-interactive --message "Release v%s [skip ci]" --tag "latest"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push git commit
+        if: github.event_name != 'pull_request'
+        run: git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.12",
+  "version": "0.3.1-pre.13",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.0",
+  "version": "0.3.1-pre.7",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.7",
+  "version": "0.3.1-pre.8",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.9",
+  "version": "0.3.1-pre.10",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.13",
+  "version": "0.3.1-pre.14",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.11",
+  "version": "0.3.1-pre.12",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.8",
+  "version": "0.3.1-pre.9",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.10",
+  "version": "0.3.1-pre.11",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.3.1-pre.14",
+  "version": "0.3.1-pre.15",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",


### PR DESCRIPTION
This PR adds a job that published a package to NPM package registry on every release created, merge to main or manual workflow dispatch.

Depends on https://github.com/keep-network/hardhat-helpers/pull/7