### PR TITLE
Snapshot helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import forking from "./forking"
 import * as number from "./number"
 import ownable from "./ownable"
 import time from "./time"
+import snapshot from "./snapshot"
 
 import "./type-extensions"
 
@@ -30,6 +31,9 @@ extendEnvironment((hre) => {
       }),
       time: lazyObject(() => {
         return time(hre)
+      }),
+      snapshot: lazyObject(() => {
+        return snapshot(hre)
       }),
     }
   })

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,0 +1,40 @@
+import { JsonRpcProvider } from "@ethersproject/providers"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+const snapshotIdsStack: any[] = []
+
+export interface HardhatSnapshotHelpers {
+  createSnapshot(): Promise<void>
+  restoreSnapshot(): Promise<void>
+}
+
+/**
+ * Snapshot the state of the blockchain at the current.
+ * @param {JsonRpcProvider} provider Ethers provider
+ */
+export async function createSnapshot(provider: JsonRpcProvider): Promise<void> {
+  const snapshotId = await provider.send("evm_snapshot", [])
+  snapshotIdsStack.push(snapshotId)
+}
+
+/**
+ * Restores the chain to a latest snapshot.
+ * @param {JsonRpcProvider} provider Ethers provider
+ */
+export async function restoreSnapshot(
+  provider: JsonRpcProvider
+): Promise<void> {
+  const snapshotId = snapshotIdsStack.pop()
+  await provider.send("evm_revert", [snapshotId])
+}
+
+export default function (
+  hre: HardhatRuntimeEnvironment
+): HardhatSnapshotHelpers {
+  const provider = hre.ethers.provider
+
+  return {
+    createSnapshot: () => createSnapshot(provider),
+    restoreSnapshot: () => restoreSnapshot(provider),
+  }
+}

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -6,6 +6,7 @@ import type { HardhatOwnableHelpers } from "./ownable"
 import type { HardhatTimeHelpers } from "./time"
 import type { HardhatForkingHelpers } from "./forking"
 import type { HardhatNumberHelpers } from "./number"
+import type { HardhatSnapshotHelpers } from "./snapshot"
 
 declare module "hardhat/types/runtime" {
   export interface HardhatRuntimeEnvironment {
@@ -20,4 +21,5 @@ export interface HardhatHelpers {
   number: HardhatNumberHelpers
   ownable: HardhatOwnableHelpers
   time: HardhatTimeHelpers
+  snapshot: HardhatSnapshotHelpers
 }

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,0 +1,52 @@
+import { useEnvironment } from "./helpers"
+import { expect } from "chai"
+import type { HardhatSnapshotHelpers } from "./snapshot"
+import type { JsonRpcProvider } from "@ethersproject/providers"
+
+describe("snapshot helpers", function () {
+  useEnvironment("hardhat-project")
+
+  let snapshotHelpers: HardhatSnapshotHelpers
+  let provider: JsonRpcProvider
+
+  beforeEach(function () {
+    snapshotHelpers = this.hre.helpers.snapshot
+    provider = this.hre.ethers.provider
+  })
+
+  it("should create and restore snapshots properly", async () => {
+    const latestBlock = async () => (await provider.getBlock("latest")).number
+
+    const mineBlocks = async (blocks: number) => {
+      for (let i = 0; i < blocks; i++) {
+        await provider.send("evm_mine", [])
+      }
+    }
+
+    const startingBlock = await latestBlock()
+
+    await mineBlocks(10)
+
+    expect(await latestBlock()).to.be.equal(startingBlock + 10)
+
+    await snapshotHelpers.createSnapshot()
+
+    await mineBlocks(15)
+
+    expect(await latestBlock()).to.be.equal(startingBlock + 25)
+
+    await snapshotHelpers.createSnapshot()
+
+    await mineBlocks(20)
+
+    expect(await latestBlock()).to.be.equal(startingBlock + 45)
+
+    await snapshotHelpers.restoreSnapshot()
+
+    expect(await latestBlock()).to.be.equal(startingBlock + 25)
+
+    await snapshotHelpers.restoreSnapshot()
+
+    expect(await latestBlock()).to.be.equal(startingBlock + 10)
+  })
+})


### PR DESCRIPTION
Here we introduce `snapshot` sub-helper to the Hardhat helpers tooling. This allows to make snapshots of the current
blockchain state and restore them in the future which is especially useful during testing. Typically, snapshotting is used to accelerate long-running tests.