### PR TITLE
Implement upgrades helpers

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,2 @@
+import "hardhat-deploy"
+import "@openzeppelin/hardhat-upgrades"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,2 +1,1 @@
 import "hardhat-deploy"
-import "@openzeppelin/hardhat-upgrades"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@openzeppelin/hardhat-upgrades": "^1.17.0",
     "@types/chai": "^4.2.21",
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^8.2.3",
@@ -43,6 +44,7 @@
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@openzeppelin/hardhat-upgrades": "^1.17.0",
     "ethers": "^5.0.32",
     "hardhat": "^2.6.4",
     "hardhat-deploy": "^0.8.11"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "eslint . --ext .js,.ts --fix",
     "test": "mocha --exit --recursive 'test/**/*.test.ts'",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.export.json",
     "prepare": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.4.1-pre.2",
+  "version": "0.5.0-pre.5",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/src/account.ts
+++ b/src/account.ts
@@ -13,7 +13,7 @@ export type FundOptions = {
 export interface HardhatAccountHelpers {
   impersonateAccount(
     accountAddress: string,
-    fundOptions: FundOptions
+    fundOptions?: FundOptions
   ): Promise<SignerWithAddress>
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as number from "./number"
 import ownable from "./ownable"
 import time from "./time"
 import snapshot from "./snapshot"
+import upgrades from "./upgrades"
 
 import "./type-extensions"
 
@@ -34,6 +35,9 @@ extendEnvironment((hre) => {
       }),
       snapshot: lazyObject(() => {
         return snapshot(hre)
+      }),
+      upgrades: lazyObject(() => {
+        return upgrades(hre)
       }),
     }
   })

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -7,6 +7,7 @@ import type { HardhatTimeHelpers } from "./time"
 import type { HardhatForkingHelpers } from "./forking"
 import type { HardhatNumberHelpers } from "./number"
 import type { HardhatSnapshotHelpers } from "./snapshot"
+import type { HardhatUpgradesHelpers } from "./upgrades"
 
 declare module "hardhat/types/runtime" {
   export interface HardhatRuntimeEnvironment {
@@ -22,4 +23,5 @@ export interface HardhatHelpers {
   ownable: HardhatOwnableHelpers
   time: HardhatTimeHelpers
   snapshot: HardhatSnapshotHelpers
+  upgrades: HardhatUpgradesHelpers
 }

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,5 +1,3 @@
-import "@openzeppelin/hardhat-upgrades"
-
 import type { Contract, ContractFactory } from "ethers"
 import type { FactoryOptions, HardhatRuntimeEnvironment } from "hardhat/types"
 import type { Deployment } from "hardhat-deploy/dist/types"

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,9 +1,8 @@
-import { Contract, ContractFactory } from "ethers"
-import { Deployment } from "hardhat-deploy/dist/types"
-
 import "@openzeppelin/hardhat-upgrades"
 
+import type { Contract, ContractFactory } from "ethers"
 import type { FactoryOptions, HardhatRuntimeEnvironment } from "hardhat/types"
+import type { Deployment } from "hardhat-deploy/dist/types"
 import type {
   DeployProxyOptions,
   UpgradeProxyOptions,

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,3 +1,5 @@
+import "@openzeppelin/hardhat-upgrades"
+
 import type { Contract, ContractFactory } from "ethers"
 import type { FactoryOptions, HardhatRuntimeEnvironment } from "hardhat/types"
 import type { Deployment } from "hardhat-deploy/dist/types"

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,0 +1,123 @@
+import { Contract, ContractFactory } from "ethers"
+import { Deployment } from "hardhat-deploy/dist/types"
+
+import "@openzeppelin/hardhat-upgrades"
+
+import type { FactoryOptions, HardhatRuntimeEnvironment } from "hardhat/types"
+import type {
+  DeployProxyOptions,
+  UpgradeProxyOptions,
+} from "@openzeppelin/hardhat-upgrades/src/utils/options"
+
+export interface HardhatUpgradesHelpers {
+  deployProxy<T extends Contract>(
+    name: string,
+    opts?: UpgradesDeployOptions
+  ): Promise<T>
+  upgradeProxy<T extends Contract>(
+    currentContractName: string,
+    newContractName: string,
+    opts?: UpgradesUpgradeOptions
+  ): Promise<T>
+}
+
+export interface UpgradesDeployOptions {
+  contractName?: string
+  initializerArgs?: unknown[]
+  factoryOpts?: FactoryOptions
+  proxyOpts?: DeployProxyOptions
+}
+
+export interface UpgradesUpgradeOptions {
+  contractName?: string
+  initializerArgs?: unknown[]
+  factoryOpts?: FactoryOptions
+  proxyOpts?: UpgradeProxyOptions
+}
+
+/**
+ * Deploys contract as a TransparentProxy.
+ *
+ * @param {HardhatRuntimeEnvironment} hre Hardhat runtime environment.
+ * @param {string} name Contract Name
+ * @param {UpgradesDeployOptions} opts
+ */
+export async function deployProxy<T extends Contract>(
+  hre: HardhatRuntimeEnvironment,
+  name: string,
+  opts?: UpgradesDeployOptions
+): Promise<T> {
+  const { ethers, upgrades, deployments } = hre
+  const { log } = deployments
+
+  const existingDeployment = await deployments.getOrNull(name)
+  if (existingDeployment) {
+    throw new Error(
+      `${name} was already deployed at ${existingDeployment.address}`
+    )
+  }
+
+  const contractFactory: ContractFactory = await ethers.getContractFactory(
+    opts?.contractName || name,
+    opts?.factoryOpts
+  )
+
+  const contractInstance: T = (await upgrades.deployProxy(
+    contractFactory,
+    opts?.initializerArgs,
+    opts?.proxyOpts
+  )) as T
+
+  log(`Deployed ${name} with TransparentProxy at ${contractInstance.address}`)
+
+  const jsonAbi = contractInstance.interface.format(
+    ethers.utils.FormatTypes.json
+  )
+
+  const deployment: Deployment = {
+    address: contractInstance.address,
+    abi: JSON.parse(jsonAbi as string),
+    transactionHash: contractInstance.deployTransaction.hash,
+    // args: opts?.initializerArgs,
+  }
+
+  await deployments.save(name, deployment)
+
+  return contractInstance
+}
+
+async function upgradeProxy<T extends Contract>(
+  hre: HardhatRuntimeEnvironment,
+  currentContractName: string,
+  newContractName: string,
+  opts?: UpgradesUpgradeOptions
+): Promise<T> {
+  const { ethers, upgrades, deployments } = hre
+
+  const currentContract = await deployments.get(currentContractName)
+
+  const newContract = await ethers.getContractFactory(
+    opts?.contractName || newContractName,
+    opts?.factoryOpts
+  )
+
+  return upgrades.upgradeProxy(
+    currentContract.address,
+    newContract,
+    opts?.proxyOpts
+  ) as Promise<T>
+}
+
+export default function (
+  hre: HardhatRuntimeEnvironment
+): HardhatUpgradesHelpers {
+  return {
+    deployProxy: (name: string, opts?: UpgradesDeployOptions) =>
+      deployProxy(hre, name, opts),
+    upgradeProxy: (
+      currentContractName: string,
+      newContractName: string,
+      opts?: UpgradesUpgradeOptions
+    ) => upgradeProxy(hre, currentContractName, newContractName, opts),
+  }
+}

--- a/test/fixture-projects/hardhat-deploy-project/hardhat-deploy-mock/DeploymentsMock.ts
+++ b/test/fixture-projects/hardhat-deploy-project/hardhat-deploy-mock/DeploymentsMock.ts
@@ -1,4 +1,10 @@
-import type { TxOptions, CallOptions, Receipt } from "hardhat-deploy/types"
+import type {
+  TxOptions,
+  CallOptions,
+  Receipt,
+  Deployment,
+  DeploymentSubmission,
+} from "hardhat-deploy/types"
 
 /* eslint-disable no-unused-vars */
 export enum FunctionType {
@@ -35,6 +41,10 @@ export interface DeploymentsExtension {
     methodName: string,
     ...args: any[]
   ): Promise<Receipt>
+
+  get(name: string): Promise<Deployment>
+  getOrNull(name: string): Promise<Deployment | null>
+  save(name: string, deployment: DeploymentSubmission): Promise<void>
 }
 
 export class DeploymentsExtensionMock implements DeploymentsExtension {
@@ -76,6 +86,21 @@ export class DeploymentsExtensionMock implements DeploymentsExtension {
       cumulativeGasUsed: 101,
       gasUsed: 20,
     }
+  }
+
+  public async get(name: string): Promise<Deployment> {
+    return {} as Deployment
+  }
+
+  public async getOrNull(name: string): Promise<Deployment | null> {
+    return null
+  }
+
+  public async save(
+    name: string,
+    deployment: DeploymentSubmission
+  ): Promise<void> {
+    return
   }
 
   registerCall(

--- a/tsconfig.export.json
+++ b/tsconfig.export.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDirs": ["./src"]
+  },
+  "include": ["./src"],
+  "files": ["hardhat.config.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,9 +539,32 @@
     fastq "^1.6.0"
 
 "@nomiclabs/hardhat-ethers@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
-  integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.5.tgz#131b0da1b71680d5a01569f916ae878229d326d3"
+  integrity sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==
+
+"@openzeppelin/hardhat-upgrades@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.17.0.tgz#24ea0f366c3b2df985263cf8b1b796afd04d7e13"
+  integrity sha512-GNxR3/3fCKQsFpBi/r+5ib6U81UM9KCypmcOQxuCkVp9JKJ80/3hQdg1R+AQku/dlnhutPsfkCokH2LZFc5mNA==
+  dependencies:
+    "@openzeppelin/upgrades-core" "^1.14.1"
+    chalk "^4.1.0"
+    proper-lockfile "^4.1.1"
+
+"@openzeppelin/upgrades-core@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.14.1.tgz#a0e1c83f9811186ac49d286e6b43ae129097422b"
+  integrity sha512-iKlh1mbUxyfdjdEiUFyhMkqirfas+DMUu7ED53nZbHEyhcYsm+5Fl/g0Bv6bZA+a7k8kO8+22DNEKsqaDUBc2Q==
+  dependencies:
+    bn.js "^5.1.2"
+    cbor "^8.0.0"
+    chalk "^4.1.0"
+    compare-versions "^4.0.0"
+    debug "^4.1.1"
+    ethereumjs-util "^7.0.3"
+    proper-lockfile "^4.1.1"
+    solidity-ast "^0.4.15"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -1130,6 +1153,13 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
+cbor@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
+
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
@@ -1272,6 +1302,11 @@ commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
+compare-versions@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-4.1.3.tgz#8f7b8966aef7dc4282b45dfa6be98434fc18a1a4"
+  integrity sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1772,6 +1807,17 @@ ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.7, ethereumjs-util@^7.1.0:
     ethjs-util "0.1.6"
     rlp "^2.2.4"
 
+ethereumjs-util@^7.0.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz#a6885bcdd92045b06f596c7626c3e89ab3312458"
+  integrity sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.2.4"
+
 ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.2.tgz#cfd79a9a3f5cdc042d1abf29964de9caf10ec238"
@@ -2115,6 +2161,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.2.4:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 growl@1.10.5:
   version "1.10.5"
@@ -2977,6 +3028,11 @@ node-gyp-build@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -3187,6 +3243,15 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+proper-lockfile@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -3280,6 +3345,11 @@ resolve@1.17.0:
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -3424,6 +3494,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+signal-exit@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3452,6 +3527,11 @@ solc@0.7.3:
     require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
+
+solidity-ast@^0.4.15:
+  version "0.4.31"
+  resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.31.tgz#c63e42f894cd047826a05dbb8d1e1dfc17282d39"
+  integrity sha512-kX6o4XE4ihaqENuRRTMJfwQNHoqWusPENZUlX4oVb19gQdfi7IswFWnThONHSW/61umgfWdKtCBgW45iuOTryQ==
 
 source-map-support@^0.5.13, source-map-support@^0.5.17:
   version "0.5.19"


### PR DESCRIPTION
We implemented helpers for using [OpenZeppelin's upgrades plugin](https://docs.openzeppelin.com/upgrades-plugins/1.x/) along
with the [deployments plugin](https://github.com/wighawag/hardhat-deploy).
An upgradable deployment will run all the validations and use benefits of openzeppelin's upgrades plugin and store a deployment artifact along with other deployments artifacts.

The work here is based on https://github.com/threshold-network/solidity-contracts/pull/62