### PR TITLE
Read contract's ABI from deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.6.0-pre.4",
+  "version": "0.6.0-pre.5",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -2,22 +2,18 @@ import type { BaseContract } from "ethers"
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 
 export interface HardhatContractsHelpers {
-  getContract<T extends BaseContract>(
-    deploymentName: string,
-    contractName?: string
-  ): Promise<T>
+  getContract<T extends BaseContract>(deploymentName: string): Promise<T>
 }
 
 async function getContract<T extends BaseContract>(
   hre: HardhatRuntimeEnvironment,
-  deploymentName: string,
-  contractName: string = deploymentName
+  deploymentName: string
 ): Promise<T> {
+  const deployment = await hre.deployments.get(deploymentName)
+
   return (await hre.ethers.getContractAt(
-    contractName,
-    (
-      await hre.deployments.get(deploymentName)
-    ).address
+    deployment.abi,
+    deployment.address
   )) as T
 }
 
@@ -25,7 +21,6 @@ export default function (
   hre: HardhatRuntimeEnvironment
 ): HardhatContractsHelpers {
   return {
-    getContract: (deploymentName: string, contractName?: string) =>
-      getContract(hre, deploymentName, contractName),
+    getContract: (deploymentName: string) => getContract(hre, deploymentName),
   }
 }


### PR DESCRIPTION
We can get the ABI from a deployment artifact, which simplifies the
code, as we don't have to pass contract artifact name along with the
deployment name for contracts that were deployed under a different name.

Refs https://github.com/keep-network/tbtc-v2/issues/250