### PR TITLE
Return Contract from getContract

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,11 +1,11 @@
-import type { BaseContract } from "ethers"
+import type { Contract } from "ethers"
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 
 export interface HardhatContractsHelpers {
-  getContract<T extends BaseContract>(deploymentName: string): Promise<T>
+  getContract<T extends Contract>(deploymentName: string): Promise<T>
 }
 
-async function getContract<T extends BaseContract>(
+async function getContract<T extends Contract>(
   hre: HardhatRuntimeEnvironment,
   deploymentName: string
 ): Promise<T> {


### PR DESCRIPTION
Contract is the type that is originally returned by the getContractAt
function. It extends BaseContract by adding funcions mapping which is
helpful when interacting with the contract object.