### PR TITLE
Wait for proxy deploy confirmations

### DIFF
--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -67,6 +67,10 @@ export async function deployProxy<T extends Contract>(
     opts?.proxyOpts
   )) as T
 
+  // Let the transaction propagate across the ethereum nodes. This is mostly to
+  // wait for all Alchemy nodes to catch up their state.
+  await contractInstance.deployTransaction.wait(1)
+
   log(
     `Deployed ${name} as ${opts?.proxyOpts?.kind || "transparent"} proxy at ${
       contractInstance.address


### PR DESCRIPTION
When using Alchemy deployment scripts were failing at some caess. Here
we're adding a wait for the deployment transaction to let the state
propagate across the Alchemy ethereum nodes.