### PR TITLE
Add constructor args to upgrade deployment artifact

### DIFF
--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -96,7 +96,7 @@ export async function deployProxy<T extends Contract>(
     receipt: transactionReceipt,
     libraries: opts?.factoryOpts?.libraries,
     devdoc: "Contract deployed as upgradable proxy",
-    // args: opts?.initializerArgs,
+    args: opts?.proxyOpts?.constructorArgs,
   }
 
   await deployments.save(name, deployment)


### PR DESCRIPTION
We can add the constructor arguments to the artifacts of an upgradable contract.
We will need them for etherscan verification.