### PR TITLE
Fix etherscan verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.6.0-pre.14",
+  "version": "0.6.0-pre.15",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -34,7 +34,7 @@ async function verify(
     ) {
       console.log("Contract is already verified")
     } else {
-      throw err
+      console.error(err)
     }
   }
 }

--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -31,7 +31,8 @@ async function verify(
     if (err instanceof NomicLabsHardhatPluginError) {
       if (err.message.includes("Contract source code already verified")) {
         console.log("Contract is already verified")
-      }
+    } else {
+      throw err
     }
   }
 }

--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -1,6 +1,5 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { Deployment } from "hardhat-deploy/dist/types"
-import { NomicLabsHardhatPluginError } from "hardhat/plugins"
 
 export interface HardhatEtherscanHelpers {
   verify(deployment: Deployment, contract?: string): Promise<void>
@@ -28,9 +27,12 @@ async function verify(
     })
     // Catch the error to workaround https://github.com/NomicFoundation/hardhat/issues/2287
   } catch (err) {
-    if (err instanceof NomicLabsHardhatPluginError) {
-      if (err.message.includes("Contract source code already verified")) {
-        console.log("Contract is already verified")
+    if (
+      err instanceof Error &&
+      (err.message.includes("Contract source code already verified") ||
+        err.message.includes("Already Verified"))
+    ) {
+      console.log("Contract is already verified")
     } else {
       throw err
     }


### PR DESCRIPTION
We catch an error and see if its' message matches a string, but we don't
do anything if it does not. We will bubble the error up in the such case.

We noticed that the `verify:verify` job fails with two different error
messages that we want to ignore:
`Already Verified`
`Contract source code already verified`

The development package with these changes was published under `@keep-network/hardhat-helpers@0.6.0-dev.9`