### PR TITLE
Output error instead of throwing it when verification fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.6.0-pre.14",
+  "version": "0.6.0-pre.15",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -34,7 +34,7 @@ async function verify(
     ) {
       console.log("Contract is already verified")
     } else {
-      throw err
+      console.error(err)
     }
   }
 }


### PR DESCRIPTION
If verification of some contract on Etherscan fails, we don't want to throw an
error (which stops verification process), but we just want to list the error in
log. This is because when we're deploying & verifying  multiple contracts we
don't want to stop deployment of next contracts after failure in verification of
a contract in the middle of the list.

Published package: @keep-network/hardhat-helpers@0.6.0-pre.15