### PR TITLE
Publish feature packages without creating a commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,11 +40,26 @@ jobs:
           git config user.name Heimdall
           git config user.email thesis-heimdall@users.noreply.github.com
 
-      # On main merge or manual workflow dispatch publish a pre-release package.
-      # Automatically bump version based on the current version stored in package.json.
+      # On `main`` merge or manual workflow dispatch on `main` publish a
+      # pre-release package. Automatically bump version based on the current
+      # version stored in package.json.
       - name: Publish pre-release package
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: |
+          github.event_name == 'push'
+            || (github.event_name == 'workflow_dispatch'
+            && github.ref == 'main')
         run: yarn publish --non-interactive --prerelease --preid pre --message "Pre-release v%s [skip ci]" --tag "pre"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # On manual workflow dispatch on branch different than `main` publish a
+      # pre-release package without a tag. Automatically bump version based on
+      # the current version stored in package.json.
+      - name: Publish feature package
+        if: |
+          github.event_name == 'workflow_dispatch'
+            && github.ref != 'main'
+        run: yarn publish --non-interactive --prerelease --preid feature --no-git-tag-version
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -57,5 +72,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push git commit
-        if: github.event_name != 'pull_request' && github.event_name != 'release'
+        if: |
+          github.event_name == 'push' 
+            || (github.event_name == 'workflow_dispatch'
+            && github.ref == 'main')
         run: git push


### PR DESCRIPTION
When workflow gets triggered on a feature branch we don't want to create a commit automatically, because such automatically created commits are not marked as verified and with current settings of GH repo they block the PRs from merging. For such use case we decided to publish the packages under `feature` suffix (preid), without creating a commit.

Dry-runned in: https://github.com/keep-network/hardhat-helpers/actions/runs/3067386144/jobs/4953615805.