### PR TITLE
Implement task to export deployment artifacts

### DIFF
--- a/src/deployment-artifacts.ts
+++ b/src/deployment-artifacts.ts
@@ -17,17 +17,6 @@ export type DeploymentArtifactsExportConfig = {
 export function exportDeploymentArtifacts(hre: HardhatRuntimeEnvironment) {
   const networkName = hre.network.name
 
-  copyDeploymentArtifacts(hre, networkName)
-
-  // TODO: Remove address for `hardhat` network.
-
-  console.log(`${emoji("🙌 ")}Done!`)
-}
-
-function copyDeploymentArtifacts(
-  hre: HardhatRuntimeEnvironment,
-  networkName: string
-) {
   const sourceDir = path.join(hre.config.paths.deployments, networkName)
   const destinationDir = path.resolve(
     hre.config.deploymentArtifactsExport[networkName]
@@ -50,4 +39,8 @@ function copyDeploymentArtifacts(
   fs.copySync(sourceDir, destinationDir, {
     recursive: true,
   })
+
+  // TODO: Remove address for `hardhat` network.
+
+  console.log(`${emoji("🙌 ")}Done!`)
 }

--- a/src/deployment-artifacts.ts
+++ b/src/deployment-artifacts.ts
@@ -1,0 +1,53 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HardhatPluginError } from "hardhat/plugins"
+
+import fs from "fs-extra"
+import * as path from "path"
+import { emoji } from "hardhat/internal/cli/emoji"
+
+export type DeploymentArtifactsExportUserConfig = {
+  default?: string
+  [networkName: string]: string | undefined
+}
+
+export type DeploymentArtifactsExportConfig = {
+  [networkName: string]: string
+}
+
+export function exportDeploymentArtifacts(hre: HardhatRuntimeEnvironment) {
+  const networkName = hre.network.name
+
+  copyDeploymentArtifacts(hre, networkName)
+
+  // TODO: Remove address for `hardhat` network.
+
+  console.log(`${emoji("🙌 ")}Done!`)
+}
+
+function copyDeploymentArtifacts(
+  hre: HardhatRuntimeEnvironment,
+  networkName: string
+) {
+  const sourceDir = path.join(hre.config.paths.deployments, networkName)
+  const destinationDir = path.resolve(
+    hre.config.deploymentArtifactsExport[networkName]
+  )
+
+  console.log(`Exporting deployment artifacts for network ${networkName}...`)
+
+  if (!fs.pathExistsSync(sourceDir)) {
+    throw new HardhatPluginError(
+      "@keep-network/hardhat-helpers",
+      `source deployments artifacts directory doesn't exist [${sourceDir}]`
+    )
+  }
+
+  console.debug(`  Source:      ${sourceDir}\n  Destination: ${destinationDir}`)
+
+  fs.ensureDirSync(destinationDir)
+  fs.emptyDirSync(destinationDir)
+
+  fs.copySync(sourceDir, destinationDir, {
+    recursive: true,
+  })
+}

--- a/src/deployment-artifacts.ts
+++ b/src/deployment-artifacts.ts
@@ -34,7 +34,13 @@ export function exportDeploymentArtifacts(hre: HardhatRuntimeEnvironment) {
   console.debug(`  Source:      ${sourceDir}\n  Destination: ${destinationDir}`)
 
   fs.ensureDirSync(destinationDir)
-  fs.emptyDirSync(destinationDir)
+
+  if (!isDirEmpty(destinationDir)) {
+    throw new HardhatPluginError(
+      "@keep-network/hardhat-helpers",
+      `destination dir is not empty [${destinationDir}]`
+    )
+  }
 
   fs.copySync(sourceDir, destinationDir, {
     recursive: true,
@@ -43,4 +49,10 @@ export function exportDeploymentArtifacts(hre: HardhatRuntimeEnvironment) {
   // TODO: Remove address for `hardhat` network.
 
   console.log(`${emoji("🙌 ")}Done!`)
+}
+
+function isDirEmpty(dirname: string): boolean {
+  const files = fs.readdirSync(dirname)
+
+  return files.length === 0
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,10 @@ extendConfig(
 
 export const TASK_EXPORT_DEPLOYMENT_ARTIFACTS = "export-deployment-artifacts"
 
-task(TASK_EXPORT_DEPLOYMENT_ARTIFACTS).setAction(async (args, hre) => {
-  exportDeploymentArtifacts(hre)
-})
+task(TASK_EXPORT_DEPLOYMENT_ARTIFACTS)
+  .setDescription(
+    "Exports deployment artifacts for the current network to a configured path"
+  )
+  .setAction(async (args, hre) => {
+    exportDeploymentArtifacts(hre)
+  })

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,13 +116,3 @@ export const TASK_EXPORT_DEPLOYMENT_ARTIFACTS = "export-deployment-artifacts"
 task(TASK_EXPORT_DEPLOYMENT_ARTIFACTS).setAction(async (args, hre) => {
   exportDeploymentArtifacts(hre)
 })
-
-export const TASK_PREPARE_ARTIFACTS = "prepare-artifacts" // deprecated
-
-task(TASK_PREPARE_ARTIFACTS).setAction(async (args, hre) => {
-  console.warn(
-    '"prepare-artifacts" task is deprecated; ' +
-      'please use "export-deployment-artifacts instead"'
-  )
-  exportDeploymentArtifacts(hre)
-})

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,8 @@ extendConfig(
             path.join(config.paths.root, networkDestinationDir)
           )
         }
+
+        config.deploymentArtifactsExport[networkName] = networkDestinationDir
       }
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,14 +88,14 @@ extendConfig(
 
     const networks = Object.keys(config.networks)
 
-    networks.forEach((value: string) => {
+    networks.forEach((networkName: string) => {
       if (
         exportUserConfig === undefined ||
-        exportUserConfig[value] === undefined
+        exportUserConfig[networkName] === undefined
       ) {
-        config.deploymentArtifactsExport[value] = defaultDestinationDir
+        config.deploymentArtifactsExport[networkName] = defaultDestinationDir
       } else {
-        let networkDestinationDir = exportUserConfig[value]!
+        let networkDestinationDir = exportUserConfig[networkName]!
 
         if (path.isAbsolute(networkDestinationDir)) {
           networkDestinationDir = networkDestinationDir

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
-import { extendEnvironment, task } from "hardhat/config"
-import { HardhatPluginError, lazyObject } from "hardhat/plugins"
-import { enableEmoji, emoji } from "hardhat/internal/cli/emoji"
+import { extendConfig, extendEnvironment, task } from "hardhat/config"
+import { lazyObject } from "hardhat/plugins"
+import { enableEmoji } from "hardhat/internal/cli/emoji"
 
-import * as types from "hardhat/internal/core/params/argumentTypes"
-import fs from "fs-extra"
 import * as path from "path"
 
 import account from "./account"
 import * as address from "./address"
 import contracts from "./contracts"
+import { exportDeploymentArtifacts } from "./deployment-artifacts"
 import etherscan from "./etherscan"
 import forking from "./forking"
 import * as number from "./number"
@@ -22,6 +21,8 @@ import "./type-extensions"
 
 import "hardhat-deploy/dist/src/type-extensions"
 import "@openzeppelin/hardhat-upgrades/dist/type-extensions"
+
+import type { HardhatConfig, HardhatUserConfig } from "hardhat/types"
 
 extendEnvironment((hre) => {
   if (hre.hardhatArguments.emoji) {
@@ -67,42 +68,59 @@ extendEnvironment((hre) => {
   })
 })
 
-export const TASK_PREPARE_ARTIFACTS = "prepare-artifacts"
+extendConfig(
+  (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+    const exportUserConfig = userConfig.deploymentArtifactsExport
 
-task(TASK_PREPARE_ARTIFACTS)
-  .addOptionalPositionalParam(
-    "destination",
-    "destination folder where the artifacts files will be written to",
-    "artifacts",
-    types.string
-  )
-  .setAction(async (args, hre) => {
-    const sourceDir = path.join(hre.config.paths.deployments, hre.network.name)
-    const destinationDir = path.join(hre.config.paths.root, args.destination)
+    if (config.deploymentArtifactsExport === undefined) {
+      config.deploymentArtifactsExport = {}
+    }
 
-    console.log(
-      `Preparing deployment artifacts for network ${hre.network.name}...`
-    )
+    let defaultDestinationDir = exportUserConfig?.default ?? "artifacts"
 
-    if (!fs.pathExistsSync(sourceDir)) {
-      throw new HardhatPluginError(
-        "@keep-network/hardhat-helpers",
-        `source deployments artifacts directory doesn't exist [${sourceDir}]`
+    if (path.isAbsolute(defaultDestinationDir)) {
+      defaultDestinationDir = defaultDestinationDir
+    } else {
+      defaultDestinationDir = path.normalize(
+        path.join(config.paths.root, defaultDestinationDir)
       )
     }
 
-    console.debug(
-      `  Source:      ${sourceDir}\n  Destination: ${destinationDir}`
-    )
+    const networks = Object.keys(config.networks)
 
-    fs.ensureDirSync(destinationDir)
-    fs.emptyDirSync(destinationDir)
+    networks.forEach((value: string) => {
+      if (
+        exportUserConfig === undefined ||
+        exportUserConfig[value] === undefined
+      ) {
+        config.deploymentArtifactsExport[value] = defaultDestinationDir
+      } else {
+        let networkDestinationDir = exportUserConfig[value]!
 
-    fs.copySync(sourceDir, destinationDir, {
-      recursive: true,
+        if (path.isAbsolute(networkDestinationDir)) {
+          networkDestinationDir = networkDestinationDir
+        } else {
+          networkDestinationDir = path.normalize(
+            path.join(config.paths.root, networkDestinationDir)
+          )
+        }
+      }
     })
+  }
+)
 
-    // TODO: Remove address for `hardhat` network.
+export const TASK_EXPORT_DEPLOYMENT_ARTIFACTS = "export-deployment-artifacts"
 
-    console.log(`${emoji("🙌 ")}Done!`)
-  })
+task(TASK_EXPORT_DEPLOYMENT_ARTIFACTS).setAction(async (args, hre) => {
+  exportDeploymentArtifacts(hre)
+})
+
+export const TASK_PREPARE_ARTIFACTS = "prepare-artifacts" // deprecated
+
+task(TASK_PREPARE_ARTIFACTS).setAction(async (args, hre) => {
+  console.warn(
+    '"prepare-artifacts" task is deprecated; ' +
+      'please use "export-deployment-artifacts instead"'
+  )
+  exportDeploymentArtifacts(hre)
+})

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,3 +1,4 @@
+import "hardhat/types/config"
 import "hardhat/types/runtime"
 
 import type { HardhatAccountHelpers } from "./account"
@@ -11,6 +12,20 @@ import type { HardhatNumberHelpers } from "./number"
 import type { HardhatSignersHelpers } from "./signers"
 import type { HardhatSnapshotHelpers } from "./snapshot"
 import type { HardhatUpgradesHelpers } from "./upgrades"
+import {
+  DeploymentArtifactsExportConfig,
+  DeploymentArtifactsExportUserConfig,
+} from "./deployment-artifacts"
+
+declare module "hardhat/types/config" {
+  export interface HardhatUserConfig {
+    deploymentArtifactsExport?: DeploymentArtifactsExportUserConfig
+  }
+
+  export interface HardhatConfig {
+    deploymentArtifactsExport: DeploymentArtifactsExportConfig
+  }
+}
 
 declare module "hardhat/types/runtime" {
   export interface HardhatRuntimeEnvironment {


### PR DESCRIPTION
Deployment artifacts are stored in `/deployments/<network>` directory. The directory may contain artifacts from multiple networks.

We publish separate NPM packages for each network (i.e. `development`, `goerli`, `mainnet`). Our expectation is that an NPM package will contain deployment artifacts in the `artifacts/` directory, without the `<network>` subdirectory. To copy the artifacts we used the old `prepare-artifacts` task that copied artifacts for the given network straight to the `artifacts/` directory.

Once we started deploying contracts to L2, we discovered that a package may contain L1 and L2 artifacts, so the structure of exported files has to change. We decided to export the artifacts under the following structure:
```
-- artifacts/
|- l1/
|- l2/
```

The new task `export-deployment-artifacts` allows a user to configure different export paths for each network. If no configuration is provided artifacts will be exported to the `artifacts/` directory (default setting). But the user can define the `deploymentArtifactsExport` property in the `hardhat.config.ts` file. The property will list paths for deployment artifacts export for each network, e.g.:
```js
  deploymentArtifactsExport: {
    default: "artifacts/",
    goerli: "artifacts/l1",
    mainnet: "artifacts/l1",
    arbitrumGoerli: "artifacts/l2",
    arbitrumOne: "artifacts/l2",
  }
```

### Example

The task can be invoked in the following way:
```sh
hardhat export-deployment-artifacts --network mainnet
```
As a result deployment artifacts will be copied from `deployments/mainnet` to the `artifacts/l1` directory.

### Sample package.json config

Sample configuration that should be added to `package.json` to export the artifacts for L1 and L2 before package publication:
```json
  "scripts": {
    "export-artifacts:goerli": "for i in goerli arbitrumGoerli; do yarn hardhat export-deployment-artifacts --network $i; done",
    "export-artifacts:mainnet": "for i in mainnet arbitrumOne; do yarn hardhat export-deployment-artifacts --network $i; done",
    "prepublishOnly": "npm run export-artifacts:$npm_config_network",
  }
```

