### PR TITLE
Update commiter's e-mail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           git config user.name Valkyrie
-          git config user.email 8324465+thesis-valkyrie@noreply.github.com
+          git config user.email 8324465+thesis-valkyrie@users.noreply.github.com
 
       # On `main` merge or manual workflow dispatch on `main` publish a
       # pre-release package. Automatically bump version based on the current

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           git config user.name Valkyrie
-          git config user.email valkyrie@thesis.co
+          git config user.email 8324465+thesis-valkyrie@noreply.github.com
 
       # On `main` merge or manual workflow dispatch on `main` publish a
       # pre-release package. Automatically bump version based on the current

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           git config user.name Valkyrie
-          git config user.email 8324465+thesis-valkyrie@users.noreply.github.com
+          git config user.email 38324465+thesis-valkyrie@users.noreply.github.com
 
       # On `main` merge or manual workflow dispatch on `main` publish a
       # pre-release package. Automatically bump version based on the current


### PR DESCRIPTION
When using private email, Git throws
```
error: GH007: Your push would publish a private email address.
```
during `git push`.
We need to make commits using a noreply e-mail (or change GH's 'Keep my email address private' setting).

See: https://stackoverflow.com/questions/43863522/error-your-push-would-publish-a-private-email-address.

Ref: https://github.com/keep-network/hardhat-helpers/issues/42