### PR TITLE
Release 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/hardhat-helpers",
-  "version": "0.6.0-pre.20",
+  "version": "0.7.0",
   "author": "Jakub Nowakowski <jakub.nowakowski@keep.network>",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Version update to 0.7.0 after updating packages to latest versions in https://github.com/keep-network/hardhat-helpers/pull/44