### PR TITLE
Extract deployment transaction from upgraded contract

### DIFF
--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -156,6 +156,8 @@ async function upgradeProxy<T extends Contract>(
   // This is a workaround to get the deployment transaction. The upgradeProxy attaches
   // the deployment transaction to the field under a different name than ethers
   // contract.deploymentTransaction() function expects.
+  // TODO: Remove this workaround once the issue is fixed on the OpenZeppelin side.
+  // Tracked in: https://github.com/keep-network/hardhat-helpers/issues/49
   const deploymentTransaction =
     newContractInstance.deployTransaction as unknown as ContractTransactionResponse
 

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,6 +1,10 @@
 import "@openzeppelin/hardhat-upgrades"
 
-import type { Contract, ContractFactory } from "ethers"
+import type {
+  Contract,
+  ContractFactory,
+  ContractTransactionResponse,
+} from "ethers"
 import type {
   Artifact,
   FactoryOptions,
@@ -149,7 +153,11 @@ async function upgradeProxy<T extends Contract>(
     opts?.proxyOpts
   )) as T
 
-  const deploymentTransaction = newContractInstance.deploymentTransaction()
+  // This is a workaround to get the deployment transaction. The upgradeProxy attaches
+  // the deployment transaction to the field under a different name than ethers
+  // contract.deploymentTransaction() function expects.
+  const deploymentTransaction =
+    newContractInstance.deployTransaction as unknown as ContractTransactionResponse
 
   // Let the transaction propagate across the ethereum nodes. This is mostly to
   // wait for all Alchemy nodes to catch up their state.


### PR DESCRIPTION
### What

After the proxy contract was upgraded we had a problem with extracting the deployment transaction via `contract.deploymentTransaction()` from ethers. 

It was happening because OpenZeppelin's `upgradeProxy` was replacing deployment tx on the proxy contract but the field was different than what ethers function expected. Let's make it work by directly using the field that `upgradeProxy` adds to the contact's object.

#### `deployProxy` implementation:
[source](https://github.com/OpenZeppelin/openzeppelin-upgrades/blob/master/packages/plugin-hardhat/src/upgrade-proxy.ts#L46C10-L46C27)
![image](https://github.com/keep-network/hardhat-helpers/assets/20949277/5ac8b79d-5f18-470e-9b9f-1b86d807362f)

#### `deploymentTransaction` implementation:
[source](https://github.com/ethers-io/ethers.js/blob/v6.10.0/src.ts/contract/contract.ts#L880)
![image](https://github.com/keep-network/hardhat-helpers/assets/20949277/364ea98f-c378-4dc3-be98-9eb505fd4aa5)

