### PR TITLE
Add a `waitForTransaction` to time helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ extendEnvironment((hre) => {
         return ownable(hre)
       }),
       time: lazyObject(() => {
-        return time()
+        return time(hre)
       }),
       signers: lazyObject(() => {
         return signers(hre)


### PR DESCRIPTION
The [hardhat-ethers](https://github.com/NomicFoundation/hardhat/blob/8f47553a88eb1251907398513449bc15689041d6/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts#L362-L368) version is unimplemented, so we provide one.

